### PR TITLE
swgemu.sql Fix to Allow Character Deletion

### DIFF
--- a/MMOCoreORB/sql/swgemu.sql
+++ b/MMOCoreORB/sql/swgemu.sql
@@ -272,6 +272,7 @@ CREATE TABLE  `swgemu`.`deleted_characters` (
   `gender` tinyint(1) NOT NULL DEFAULT '0',
   `template` tinytext NOT NULL,
   `creation_date` TIMESTAMP NOT NULL,
+  `db_deleted` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`character_oid`),
   KEY `acc_idx` (`account_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;


### PR DESCRIPTION
Updated the swgemu.sql file to include a "db_deleted" column in the "deleted_characters" table, which is required for character deletion to work via the character manager in-game. Not sure how this was removed, but it appears to be missing from the current swgemu.sql file.